### PR TITLE
Fix empty interface declarations in textarea.tsx and command.tsx

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.ComponentProps<"textarea">;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (


### PR DESCRIPTION
Fixed empty interface declarations in `textarea.tsx` and `command.tsx` as requested to satisfy the `no-empty-object-type` ESLint rule. The changes are structural and do not affect component functionality. Verified with ESLint.

---
*PR created automatically by Jules for task [15883766865438892918](https://jules.google.com/task/15883766865438892918) started by @3rdeyeadvisors*