### PR TITLE
Rename package to pulseos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "pulseos",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite_react_shadcn_ts",
+      "name": "pulseos",
       "version": "0.0.0",
       "dependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "pulseos",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
Updated the package name in package.json from "vite_react_shadcn_ts" to "pulseos" as requested. Verified the change by running a successful build.

---
*PR created automatically by Jules for task [7071676146396887229](https://jules.google.com/task/7071676146396887229) started by @3rdeyeadvisors*