### PR TITLE
Fix let → const in TasksCard and add missing useCallback deps

### DIFF
--- a/src/components/dashboard/DailyQuoteCard.tsx
+++ b/src/components/dashboard/DailyQuoteCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { Quote, RefreshCw } from 'lucide-react';
@@ -17,7 +17,7 @@ export function DailyQuoteCard() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  const fetchQuote = async (isRefresh = false) => {
+  const fetchQuote = useCallback(async (isRefresh = false) => {
     if (!user) return;
 
     if (isRefresh) setRefreshing(true);
@@ -58,11 +58,11 @@ export function DailyQuoteCard() {
       setLoading(false);
       setRefreshing(false);
     }
-  };
+  }, [user]);
 
   useEffect(() => {
     fetchQuote();
-  }, [user]);
+  }, [fetchQuote]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/FoodRecommendationsCard.tsx
+++ b/src/components/dashboard/FoodRecommendationsCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { Utensils, Coffee, Sun, Moon, RefreshCw, MapPin, X, Navigation } from 'lucide-react';
@@ -42,7 +42,7 @@ export function FoodRecommendationsCard() {
   const [selectedRec, setSelectedRec] = useState<FoodRecommendation | null>(null);
   const [userCity, setUserCity] = useState<string>('');
 
-  const fetchRecommendations = async (isRefresh = false) => {
+  const fetchRecommendations = useCallback(async (isRefresh = false) => {
     if (!user || !session) return;
 
     if (isRefresh) setRefreshing(true);
@@ -94,7 +94,7 @@ export function FoodRecommendationsCard() {
       setLoading(false);
       setRefreshing(false);
     }
-  };
+  }, [user, session]);
 
   useEffect(() => {
     fetchRecommendations();
@@ -111,7 +111,7 @@ export function FoodRecommendationsCard() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [user, session]);
+  }, [user, session, fetchRecommendations]);
 
   const openInMaps = (name: string) => {
     const query = encodeURIComponent(`${name}${userCity ? `, ${userCity}` : ''}`);

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { Newspaper, ExternalLink, RefreshCw } from 'lucide-react';
@@ -35,7 +35,7 @@ export function NewsCard() {
   const [error, setError] = useState<string | null>(null);
   const hasFetched = useRef(false);
 
-  const fetchNews = async (isRefresh = false) => {
+  const fetchNews = useCallback(async (isRefresh = false) => {
     if (!user) return;
 
     if (isRefresh) setRefreshing(true);
@@ -133,7 +133,7 @@ export function NewsCard() {
       setLoading(false);
       setRefreshing(false);
     }
-  };
+  }, [user]);
 
   useEffect(() => {
     if (user && !hasFetched.current) {
@@ -153,7 +153,7 @@ export function NewsCard() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [user]);
+  }, [user, fetchNews]);
 
   const formatTime = (dateStr: string) => {
     try {

--- a/src/components/dashboard/TasksCard.tsx
+++ b/src/components/dashboard/TasksCard.tsx
@@ -97,7 +97,7 @@ export function TasksCard() {
       ];
 
       // Fetch all accepted invites for these tasks to get participants
-      let participantsMap: Record<string, Participant[]> = {};
+      const participantsMap: Record<string, Participant[]> = {};
       
       if (allTaskIds.length > 0) {
         const { data: allInvites } = await supabase

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bell, Check, Trash2, X, ChevronRight, CheckCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -82,6 +82,34 @@ export function NotificationBell() {
     }
   };
 
+  const fetchNotifications = useCallback(async () => {
+    if (!user) return;
+
+    // First, cleanup old notifications (older than 30 days)
+    const thirtyDaysAgo = subDays(new Date(), 30).toISOString();
+    await supabase
+      .from('notifications')
+      .delete()
+      .eq('user_id', user.id)
+      .lt('created_at', thirtyDaysAgo);
+
+    // Fetch recent notifications
+    const { data, error } = await supabase
+      .from('notifications')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(50);
+
+    if (error) {
+      console.error('Error fetching notifications:', error);
+      return;
+    }
+
+    setNotifications(data || []);
+    setUnreadCount(data?.filter((n) => !n.read).length || 0);
+  }, [user]);
+
   useEffect(() => {
     if (!user) return;
 
@@ -125,35 +153,7 @@ export function NotificationBell() {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [user]);
-
-  const fetchNotifications = async () => {
-    if (!user) return;
-
-    // First, cleanup old notifications (older than 30 days)
-    const thirtyDaysAgo = subDays(new Date(), 30).toISOString();
-    await supabase
-      .from('notifications')
-      .delete()
-      .eq('user_id', user.id)
-      .lt('created_at', thirtyDaysAgo);
-
-    // Fetch recent notifications
-    const { data, error } = await supabase
-      .from('notifications')
-      .select('*')
-      .eq('user_id', user.id)
-      .order('created_at', { ascending: false })
-      .limit(50);
-
-    if (error) {
-      console.error('Error fetching notifications:', error);
-      return;
-    }
-
-    setNotifications(data || []);
-    setUnreadCount(data?.filter((n) => !n.read).length || 0);
-  };
+  }, [user, fetchNotifications]);
 
   const clearReadNotifications = async () => {
     if (!user) return;

--- a/src/components/settings/NotificationsTab.tsx
+++ b/src/components/settings/NotificationsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -34,11 +34,7 @@ export function NotificationsTab() {
     leaderboard_reminders: false,
   });
 
-  useEffect(() => {
-    fetchPreferences();
-  }, [user]);
-
-  const fetchPreferences = async () => {
+  const fetchPreferences = useCallback(async () => {
     if (!user) return;
 
     const { data, error } = await supabase
@@ -60,7 +56,11 @@ export function NotificationsTab() {
       });
     }
     setLoading(false);
-  };
+  }, [user]);
+
+  useEffect(() => {
+    fetchPreferences();
+  }, [fetchPreferences]);
 
   const updatePreference = async (key: keyof EmailPreferences, value: boolean) => {
     if (!user) return;


### PR DESCRIPTION
This PR addresses several mechanical lint errors and warnings:
1. One `prefer-const` error in `TasksCard.tsx` where `participantsMap` was declared with `let` but never reassigned.
2. Five `react-hooks/exhaustive-deps` warnings where fetch functions defined inside components were used in `useEffect` without being wrapped in `useCallback` or included in the dependency array.

Changes:
- `src/components/dashboard/TasksCard.tsx`: Changed `let participantsMap` to `const participantsMap`.
- `src/components/dashboard/DailyQuoteCard.tsx`: Wrapped `fetchQuote` in `useCallback([user])` and added to `useEffect`.
- `src/components/dashboard/FoodRecommendationsCard.tsx`: Wrapped `fetchRecommendations` in `useCallback([user, session])` and added to `useEffect`.
- `src/components/dashboard/NewsCard.tsx`: Wrapped `fetchNews` in `useCallback([user])` and added to `useEffect`.
- `src/components/notifications/NotificationBell.tsx`: Wrapped `fetchNotifications` in `useCallback([user])` and added to `useEffect`.
- `src/components/settings/NotificationsTab.tsx`: Wrapped `fetchPreferences` in `useCallback([user])` and added to `useEffect`.

---
*PR created automatically by Jules for task [3813543463883815903](https://jules.google.com/task/3813543463883815903) started by @3rdeyeadvisors*