### PR TITLE
Fix 'any' types in useNotifications, useSubscription, and useLeaderboard hooks

### DIFF
--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -3,6 +3,15 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { startOfWeek, endOfWeek, format } from 'date-fns';
 
+interface LeaderboardRow {
+  user_id: string;
+  username: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+  total_score: number;
+  rank: number;
+}
+
 interface LeaderboardEntry {
   user_id: string;
   username: string | null;
@@ -58,7 +67,7 @@ export function useLeaderboard() {
       setLeaderboard([]);
     } else if (leaderboardData && leaderboardData.length > 0) {
       // Fetch verified status and roles for all users
-      const userIds = leaderboardData.map((entry: any) => entry.user_id);
+      const userIds = leaderboardData.map((entry: LeaderboardRow) => entry.user_id);
       
       const [profilesResult, rolesResult] = await Promise.all([
         supabase
@@ -75,7 +84,7 @@ export function useLeaderboard() {
       const verifiedMap = new Map(profilesResult.data?.map(p => [p.user_id, p.verified]) || []);
       const founderSet = new Set(rolesResult.data?.map(r => r.user_id) || []);
 
-      const entries = leaderboardData.map((entry: any) => ({
+      const entries = leaderboardData.map((entry: LeaderboardRow) => ({
         ...entry,
         verified: verifiedMap.get(entry.user_id) || false,
         isFounder: founderSet.has(entry.user_id),

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,6 +1,12 @@
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'An unexpected error occurred';
+}
+
 type NotificationType = 'welcome' | 'daily_digest' | 'event_reminder' | 'task_reminder' | 'weather_alert' | 'new_recommendation' | 'system';
 
 export function useNotifications() {
@@ -10,7 +16,7 @@ export function useNotifications() {
     type: NotificationType,
     title: string,
     message: string,
-    data?: Record<string, any>
+    data?: Record<string, string | number | boolean | null | undefined>
   ) => {
     if (!user) return { error: 'Not authenticated' };
 
@@ -48,9 +54,9 @@ export function useNotifications() {
 
       if (error) throw error;
       return { data };
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error sending welcome email:', error);
-      return { error: error.message };
+      return { error: getErrorMessage(error) };
     }
   };
 
@@ -81,9 +87,9 @@ export function useNotifications() {
 
       if (error) throw error;
       return { data };
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error sending notification email:', error);
-      return { error: error.message };
+      return { error: getErrorMessage(error) };
     }
   };
 
@@ -108,9 +114,9 @@ export function useNotifications() {
 
       if (error) throw error;
       return { data };
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error sending task reminder:', error);
-      return { error: error.message };
+      return { error: getErrorMessage(error) };
     }
   };
 

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -10,6 +10,12 @@ import {
   getOfferings 
 } from '@/services/revenueCatService';
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'An unexpected error occurred';
+}
+
 export interface SubscriptionStatus {
   subscribed: boolean;
   is_grandfathered: boolean;
@@ -28,7 +34,7 @@ export function useSubscription() {
   const [loading, setLoading] = useState(true);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
-  const [offerings, setOfferings] = useState<any>(null);
+  const [offerings, setOfferings] = useState<unknown>(null);
 
   const checkSubscription = useCallback(async () => {
     if (!user) {
@@ -126,9 +132,9 @@ export function useSubscription() {
           toast.success('Subscription successful!');
           await checkSubscription();
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error('Error with native purchase:', err);
-        toast.error(err.message || 'Failed to complete purchase');
+        toast.error(getErrorMessage(err));
       } finally {
         setCheckoutLoading(false);
       }


### PR DESCRIPTION
Resolved ESLint 'no-explicit-any' errors in three React hooks: 'useNotifications.ts', 'useSubscription.ts', and 'useLeaderboard.ts'. 

Key changes include:
1. Added a 'getErrorMessage(error: unknown)' helper function to safely extract messages from caught errors, replacing 'error.message' where 'error' was 'any'.
2. Updated 'catch' blocks to use 'unknown' instead of 'any' across all three files.
3. Defined a specific 'LeaderboardRow' interface for the Supabase 'get_friends_leaderboard' RPC result in 'useLeaderboard.ts', ensuring property names ('total_score', 'user_id', etc.) match the database schema.
4. Refined the 'data' parameter in 'useNotifications.ts''s 'createNotification' from 'Record<string, any>' to a more specific type including primitives and null/undefined.
5. Changed the 'offerings' state in 'useSubscription.ts' from 'any' to 'unknown' to align with the task requirements.

These changes improve type safety and maintainability by eliminating the 'any' escape hatch in these critical hooks.

---
*PR created automatically by Jules for task [12011928639546300964](https://jules.google.com/task/12011928639546300964) started by @3rdeyeadvisors*