### PR TITLE
Implement PWA Update Prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import { PreferencesProvider } from "@/contexts/PreferencesContext";
 import { useDeepLinks } from "@/hooks/useDeepLinks";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { UpdatePrompt } from '@/components/UpdatePrompt';
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 
@@ -97,6 +98,7 @@ const App = () => (
             <TooltipProvider>
               <Toaster />
               <Sonner />
+              <UpdatePrompt />
               <BrowserRouter>
                 <NativeFeatureInitializer />
                 <Suspense fallback={<PageLoader />}>

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,0 +1,32 @@
+import { useRegisterSW } from 'virtual:pwa-register/react';
+import { toast } from 'sonner';
+import { useEffect } from 'react';
+
+export function UpdatePrompt() {
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(swUrl, r) {
+      // Check for updates every 60 seconds
+      if (r) {
+        setInterval(() => r.update(), 60_000);
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (needRefresh) {
+      toast('New version available!', {
+        description: 'Tap to update PulseOS now.',
+        duration: Infinity,
+        action: {
+          label: 'Update',
+          onClick: () => updateServiceWorker(true),
+        },
+      });
+    }
+  }, [needRefresh, updateServiceWorker]);
+
+  return null;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(({ mode }) => ({
     react(),
     mode === "development" && componentTagger(),
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt",
       includeAssets: ["favicon.ico", "apple-touch-icon.png", "android-chrome-192x192.png", "android-chrome-512x512.png"],
       manifest: {
         name: "PulseOS - Your Personal Life Dashboard",


### PR DESCRIPTION
This change implements a manual update prompt for the PulseOS PWA. Previously, the app was configured to silently update but only activate when the tab was closed, which could leave long-running sessions on outdated versions.

The update includes:
1.  **Configuration Change**: Switched the PWA registration strategy to `prompt` in `vite.config.ts`.
2.  **New Component**: Added `UpdatePrompt.tsx`, which uses the `useRegisterSW` hook to listen for service worker updates and shows a toast notification using `sonner` when a new version is available. It also polls for updates every 60 seconds.
3.  **App Integration**: Included the `<UpdatePrompt />` component in the main application layout in `App.tsx`.
4.  **Type Support**: Added the necessary TypeScript reference for `vite-plugin-pwa/react` in `src/vite-env.d.ts`.

---
*PR created automatically by Jules for task [8707989445584047358](https://jules.google.com/task/8707989445584047358) started by @3rdeyeadvisors*