### PR TITLE
Fix chat message flickering and duplication

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -50,6 +50,8 @@ interface Message {
 }
 
 export default function Chat() {
+  const msgIdCounter = useRef(0);
+  const nextId = useCallback(() => `msg-${++msgIdCounter.current}`, []);
   const navigate = useNavigate();
   const location = useLocation();
   const { user, loading } = useAuth();
@@ -76,15 +78,17 @@ export default function Chat() {
   };
 
   // Sync saved messages to local state with IDs
+  const historyLoadedRef = useRef(false);
   useEffect(() => {
-    if (!loadingHistory) {
-      setMessages(savedMessages.map((m, i) => ({
-        id: `msg-${i}-${Date.now()}`,
+    if (!loadingHistory && !historyLoadedRef.current) {
+      historyLoadedRef.current = true;
+      setMessages(savedMessages.map((m) => ({
+        id: nextId(),
         role: m.role,
         content: m.content,
       })));
     }
-  }, [savedMessages, loadingHistory]);
+  }, [loadingHistory, savedMessages, nextId]);
 
   useEffect(() => {
     if (!loading && !user) {
@@ -124,20 +128,6 @@ export default function Chat() {
     fetchUserData();
   }, [user, preferences]);
 
-  // Handle initial message from navigation state
-  const [initialMessageSent, setInitialMessageSent] = useState(false);
-  useEffect(() => {
-    if (initialMessage && !initialMessageSent && userContext && !loadingHistory) {
-      setInitialMessageSent(true);
-      window.history.replaceState({}, document.title);
-      sendMessage(initialMessage);
-    }
-  }, [initialMessage, initialMessageSent, userContext, loadingHistory]);
-
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
-
   // Batched update function for streaming
   const scheduleUpdate = useCallback(() => {
     if (updateScheduledRef.current) return;
@@ -158,11 +148,11 @@ export default function Chat() {
     });
   }, []);
 
-  const sendMessage = async (content: string) => {
+  const sendMessage = useCallback(async (content: string) => {
     if (!content.trim() || isLoading) return;
 
-    const userMessageId = `user-${Date.now()}`;
-    const assistantMessageId = `assistant-${Date.now()}`;
+    const userMessageId = nextId();
+    const assistantMessageId = nextId();
     
     const userMessage: Message = { id: userMessageId, role: 'user', content };
     
@@ -285,7 +275,21 @@ export default function Chat() {
       setIsLoading(false);
       currentAssistantIdRef.current = null;
     }
-  };
+  }, [messages, isLoading, userContext, aiSettings, saveMessage, scheduleUpdate, nextId]);
+
+  // Handle initial message from navigation state
+  const [initialMessageSent, setInitialMessageSent] = useState(false);
+  useEffect(() => {
+    if (initialMessage && !initialMessageSent && userContext && !loadingHistory) {
+      setInitialMessageSent(true);
+      window.history.replaceState({}, document.title);
+      sendMessage(initialMessage);
+    }
+  }, [initialMessage, initialMessageSent, userContext, loadingHistory, sendMessage]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
 
   const handleClearChat = async () => {
     await clearMessages();


### PR DESCRIPTION
This PR addresses three root causes for chat message flickering and duplication during streaming:

1. **ID Collisions:** Replaced `Date.now()` based IDs with a stable incrementing counter (`msg-1`, `msg-2`, etc.) using `useRef` and `useCallback`.
2. **History Sync Glitch:** Updated the history sync `useEffect` to use a `historyLoadedRef`, ensuring it only runs once and doesn't regenerate message IDs when messages are saved to the database.
3. **Stale Closures:** Wrapped the `sendMessage` function in `useCallback` and correctly added it to the dependency array of the initial message `useEffect`.

Additionally, the `sendMessage` function and associated `useEffect` hooks were reordered to resolve TypeScript hoisting errors while maintaining hook stability.

---
*PR created automatically by Jules for task [11733519540803488666](https://jules.google.com/task/11733519540803488666) started by @3rdeyeadvisors*