### PR TITLE
Move Stripe publishable key to environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ VITE_REVENUECAT_ANDROID_TEST_KEY=goog_test_key_placeholder
 VITE_APP_URL=https://pulseos.tech
 VITE_STORE_LINK_IOS=https://apps.apple.com/app/pulseos/id000000000
 VITE_STORE_LINK_ANDROID=https://play.google.com/store/apps/details?id=tech.pulseos.app
+
+# Stripe Configuration
+VITE_STRIPE_PUBLISHABLE_KEY=pk_live_your_key_here

--- a/src/components/settings/EmbeddedCheckoutModal.tsx
+++ b/src/components/settings/EmbeddedCheckoutModal.tsx
@@ -14,7 +14,7 @@ import { Loader2 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 
 // Initialize Stripe with publishable key
-const stripePromise = loadStripe('pk_live_51SfNXgLxeGPiI62je3NxRYPBNDdAPyTMH6YM9m6BnKsHV0wqYDdTPjKPpSVOJKGUqzxXhDwMqfMDTbXF1r5nxSkL00T6XSi6uM');
+const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY ?? '');
 
 interface EmbeddedCheckoutModalProps {
   open: boolean;


### PR DESCRIPTION
The hardcoded Stripe publishable key in `src/components/settings/EmbeddedCheckoutModal.tsx` was replaced with an environment variable (`import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY`) to improve security and facilitate key rotation. The `.env.example` file was also updated to include this new environment variable. No other changes were made to the component file, and the code was verified to be correct and free of regressions through type checking.

---
*PR created automatically by Jules for task [4111087882452227522](https://jules.google.com/task/4111087882452227522) started by @3rdeyeadvisors*