### PR TITLE
Fix ModulesTab to use .upsert() for saving preferences

### DIFF
--- a/src/components/settings/ModulesTab.tsx
+++ b/src/components/settings/ModulesTab.tsx
@@ -77,8 +77,7 @@ export function ModulesTab() {
 
     const { error } = await supabase
       .from('preferences')
-      .update({ enabled_modules: enabledModules })
-      .eq('user_id', user.id);
+      .upsert({ user_id: user.id, enabled_modules: enabledModules }, { onConflict: 'user_id' });
 
     if (error) {
       toast.error('Failed to save module settings');


### PR DESCRIPTION
The `ModulesTab` in the settings was using `.update()` to save enabled modules. If a user did not already have a row in the `preferences` table, this operation would silently do nothing. This change replaces it with `.upsert()`, which is used in all other settings tabs, ensuring that the row is created if it's missing.

---
*PR created automatically by Jules for task [4054137590648624334](https://jules.google.com/task/4054137590648624334) started by @3rdeyeadvisors*