### PR TITLE
Fix .single() → .maybeSingle() to stop crashing for new users

### DIFF
--- a/supabase/functions/check-subscription/index.ts
+++ b/supabase/functions/check-subscription/index.ts
@@ -45,7 +45,7 @@ serve(async (req) => {
       .from("user_subscriptions")
       .select("*")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     // Check if user is grandfathered
     if (subscriptionData?.is_grandfathered) {
@@ -126,7 +126,7 @@ serve(async (req) => {
     }
 
     // Fall back to database-based trial (set on signup) if no Stripe subscription
-    if (subscriptionData?.trial_ends_at && !subscriptionData?.stripe_subscription_id) {
+    if (subscriptionData && subscriptionData.trial_ends_at && !subscriptionData.stripe_subscription_id) {
       const trialEndsAt = new Date(subscriptionData.trial_ends_at);
       const now = new Date();
       

--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -79,7 +79,7 @@ serve(async (req) => {
       .from("user_subscriptions")
       .select("trial_ends_at, status")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     // Calculate remaining trial days if user is in trial
     let trialEndTimestamp: number | undefined;


### PR DESCRIPTION
This PR addresses a critical issue where brand-new users without a record in the `user_subscriptions` table would experience application crashes during subscription checks. By replacing `.single()` with `.maybeSingle()`, the functions now handle missing records gracefully by returning `null` instead of throwing a 500 error.

Key changes:
- In `supabase/functions/check-subscription/index.ts`, the query for `subscriptionData` now uses `.maybeSingle()`.
- An explicit null guard was added to the fallback trial logic in `check-subscription/index.ts` to safely handle the null `subscriptionData`.
- In `supabase/functions/create-checkout/index.ts`, the subscription status query was updated to use `.maybeSingle()`.
- All other logic remains unchanged and remains null-safe via existing optional chaining.

---
*PR created automatically by Jules for task [10764871548192400279](https://jules.google.com/task/10764871548192400279) started by @3rdeyeadvisors*