### PR TITLE
Implement portal_return handler in Settings and update customer-portal function

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -44,6 +44,13 @@ export default function Settings() {
       searchParams.delete('canceled');
       setSearchParams(searchParams);
     }
+
+    const portalReturn = searchParams.get('portal_return');
+    if (portalReturn === 'true') {
+      toast.info('Subscription updated. Your plan status will refresh shortly.');
+      searchParams.delete('portal_return');
+      setSearchParams(searchParams);
+    }
   }, [searchParams, setSearchParams]);
 
   // Sync tab state with URL

--- a/supabase/functions/customer-portal/index.ts
+++ b/supabase/functions/customer-portal/index.ts
@@ -63,7 +63,7 @@ serve(async (req) => {
     const origin = req.headers.get("origin") || "https://pulse-life.app";
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: `${origin}/settings?tab=subscription`,
+      return_url: `${origin}/settings?tab=subscription&portal_return=true`,
     });
 
     logStep("Customer portal session created", { sessionId: portalSession.id });


### PR DESCRIPTION
This change improves the user experience after managing subscriptions in the Stripe portal. Users now receive a toast notification confirming that their plan status will refresh shortly, providing immediate feedback even if the background update hasn't completed yet.

---
*PR created automatically by Jules for task [5559377792087524272](https://jules.google.com/task/5559377792087524272) started by @3rdeyeadvisors*