### PR TITLE
Optimize Dashboard Cards to use PreferencesContext

### DIFF
--- a/src/components/dashboard/GreetingCard.tsx
+++ b/src/components/dashboard/GreetingCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { usePreferences } from '@/contexts/PreferencesContext';
 import { Sparkles } from 'lucide-react';
 
 const affirmations = [
@@ -38,8 +37,7 @@ const affirmations = [
 ];
 
 export function GreetingCard() {
-  const { user, session } = useAuth();
-  const [fullName, setFullName] = useState<string | null>(null); // null = loading
+  const { fullName: contextFullName } = usePreferences();
   const [greeting, setGreeting] = useState<string>('');
   const [affirmation, setAffirmation] = useState<string>('');
 
@@ -58,34 +56,9 @@ export function GreetingCard() {
     setAffirmation(affirmations[affirmationIndex]);
   }, []);
 
-  useEffect(() => {
-    async function fetchProfile() {
-      if (!user || !session) return;
-      
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('full_name')
-        .eq('user_id', user.id)
-        .maybeSingle();
-      
-      if (error) {
-        console.error('Profile fetch error:', error);
-        setFullName(''); // Set to empty on error
-        return;
-      }
-      
-      if (data?.full_name) {
-        setFullName(data.full_name.split(' ')[0]);
-      } else {
-        setFullName(''); // No name found
-      }
-    }
-    
-    fetchProfile();
-  }, [user, session]);
-
   // Don't show email - use neutral fallback while loading or if no name
-  const displayName = fullName === null ? '' : (fullName || 'there');
+  const firstName = contextFullName ? contextFullName.split(' ')[0] : contextFullName;
+  const displayName = firstName === null ? '' : (firstName || 'there');
 
   return (
     <div className="col-span-full p-4 sm:p-6 rounded-2xl bg-gradient-to-br from-primary/20 via-card to-accent/10 border border-primary/20 shadow-glow overflow-hidden">

--- a/src/components/dashboard/WeatherCard.tsx
+++ b/src/components/dashboard/WeatherCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { usePreferences } from '@/contexts/PreferencesContext';
 import { Cloud, Sun, CloudRain, CloudSnow, CloudLightning, Wind, Droplets } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
@@ -17,40 +16,19 @@ interface WeatherData {
 type TempUnit = 'fahrenheit' | 'celsius';
 
 export function WeatherCard() {
-  const { user, session } = useAuth();
+  const { preferences, city: profileCity, updatePreferences } = usePreferences();
   const [weather, setWeather] = useState<WeatherData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [tempUnit, setTempUnit] = useState<TempUnit>('fahrenheit');
+
+  const tempUnit: TempUnit = (preferences.temperature_unit as TempUnit) ?? 'fahrenheit';
 
   useEffect(() => {
     let isMounted = true;
 
     async function fetchWeatherAndPrefs() {
-      if (!user || !session) return;
-
       try {
-        // Get user's city and temp unit preference
-        const [{ data: profile }, { data: prefs }] = await Promise.all([
-          supabase
-            .from('profiles')
-            .select('city')
-            .eq('user_id', user.id)
-            .maybeSingle(),
-          supabase
-            .from('preferences')
-            .select('temperature_unit')
-            .eq('user_id', user.id)
-            .maybeSingle(),
-        ]);
-
-        if (!isMounted) return;
-
-        if (prefs?.temperature_unit) {
-          setTempUnit(prefs.temperature_unit as TempUnit);
-        }
-
-        const userCity = profile?.city || 'New York';
+        const userCity = profileCity || 'New York';
 
         // Fetch real weather data
         const response = await fetch(
@@ -100,18 +78,11 @@ export function WeatherCard() {
       isMounted = false;
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [user, session]);
+  }, [profileCity]);
 
   const toggleUnit = async () => {
     const newUnit: TempUnit = tempUnit === 'fahrenheit' ? 'celsius' : 'fahrenheit';
-    setTempUnit(newUnit);
-
-    if (user) {
-      await supabase
-        .from('preferences')
-        .update({ temperature_unit: newUnit })
-        .eq('user_id', user.id);
-    }
+    await updatePreferences({ temperature_unit: newUnit });
   };
 
   const convertTemp = (tempF: number): number => {

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -37,6 +37,7 @@ interface PreferencesContextType {
   loading: boolean;
   avatarUrl: string | null;
   fullName: string | null;
+  city: string | null;
   aiName: string;
   updatePreferences: (updates: Partial<Preferences>) => Promise<void>;
   refreshPreferences: () => Promise<void>;
@@ -50,6 +51,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [fullName, setFullName] = useState<string | null>(null); // null = loading
+  const [city, setCity] = useState<string | null>(null);
   const [aiName, setAiName] = useState<string>('Pulse');
 
   const fetchPreferences = useCallback(async () => {
@@ -99,6 +101,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       if (!user) {
         setAvatarUrl(null);
         setFullName(null);
+        setCity(null);
         setAiName('Pulse');
         return;
       }
@@ -107,7 +110,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       const [{ data: profile }, { data: prefs }] = await Promise.all([
         supabase
           .from('profiles')
-          .select('avatar_url, full_name')
+          .select('avatar_url, full_name, city')
           .eq('user_id', user.id)
           .single(),
         supabase
@@ -120,8 +123,10 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       if (profile) {
         setAvatarUrl(profile.avatar_url);
         setFullName(profile.full_name || '');
+        setCity(profile.city || null);
       } else {
         setFullName(''); // No profile found, set to empty
+        setCity(null);
       }
       if (prefs?.ai_name) {
         setAiName(prefs.ai_name);
@@ -199,6 +204,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         loading,
         avatarUrl,
         fullName,
+        city,
         aiName,
         updatePreferences,
         refreshPreferences


### PR DESCRIPTION
Optimized the GreetingCard and WeatherCard components on the dashboard to use the existing PreferencesContext instead of making direct, redundant Supabase queries for profile (name, city) and preference (temperature unit) data. This reduces database roundtrips and improves dashboard load performance.

---
*PR created automatically by Jules for task [12920878497690289565](https://jules.google.com/task/12920878497690289565) started by @3rdeyeadvisors*