### PR TITLE
Add feature list to Friends paywall + export Place/Event types from placesService

### DIFF
--- a/src/pages/Friends.tsx
+++ b/src/pages/Friends.tsx
@@ -18,7 +18,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Loader2, Users, UserPlus, Send, Inbox, Trophy, Globe, CalendarCheck, Search, Lock, Crown } from 'lucide-react';
+import { Loader2, Users, UserPlus, Send, Inbox, Trophy, Globe, CalendarCheck, Search, Lock, Crown, Check } from 'lucide-react';
 
 export default function Friends() {
   const navigate = useNavigate();
@@ -83,6 +83,21 @@ export default function Friends() {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
+              <div className="space-y-2 text-left mt-2">
+                {[
+                  'Add and connect with friends',
+                  'Weekly activity leaderboards',
+                  'Send and receive activity invites',
+                  'See friend progress and streaks',
+                ].map((feature) => (
+                  <div key={feature} className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <div className="h-4 w-4 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0">
+                      <Check className="h-2.5 w-2.5 text-primary" />
+                    </div>
+                    {feature}
+                  </div>
+                ))}
+              </div>
               <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
                 <Users className="h-4 w-4" />
                 <span>Build your social network and plan activities together</span>

--- a/src/services/placesService.ts
+++ b/src/services/placesService.ts
@@ -1,6 +1,6 @@
 import { supabase } from "@/integrations/supabase/client";
 
-interface Place {
+export interface Place {
   id: string;
   name: string;
   type: string;
@@ -12,7 +12,7 @@ interface Place {
   address: string;
 }
 
-interface Event {
+export interface Event {
   id: string;
   title: string;
   type: string;


### PR DESCRIPTION
This PR adds a scannable feature list to the Friends paywall to improve UX and clarity for non-subscribed users. It also exports the `Place` and `Event` interfaces from the `placesService` to satisfy prerequisites for future tasks. All changes strictly follow the user's layout and implementation requirements.

---
*PR created automatically by Jules for task [9624430263403042075](https://jules.google.com/task/9624430263403042075) started by @3rdeyeadvisors*