### PR TITLE
Fix frontend hooks + services + tailwind config

### DIFF
--- a/src/hooks/useActivityInvites.ts
+++ b/src/hooks/useActivityInvites.ts
@@ -109,7 +109,7 @@ export function useActivityInvites() {
         receiver_id: receiverId,
         activity_type: activityType,
         activity_name: activityName,
-        activity_data: activityData as any,
+        activity_data: activityData as Record<string, unknown>,
         proposed_time: proposedTime.toISOString(),
         message: message || null,
       });

--- a/src/hooks/useUsername.ts
+++ b/src/hooks/useUsername.ts
@@ -31,7 +31,7 @@ export function useUsername() {
 
   useEffect(() => {
     checkUsername();
-  }, [user, checkUsername]);
+  }, [checkUsername]);
 
   const refreshUsername = () => {
     setLoading(true);

--- a/src/services/revenueCatService.ts
+++ b/src/services/revenueCatService.ts
@@ -88,8 +88,8 @@ export const purchasePackage = async (packageId: string, offeringId: string = 'd
 
     const { customerInfo } = await Purchases.purchasePackage({ aPackage: pkg });
     return customerInfo;
-  } catch (error: any) {
-    if (error.userCancelled) {
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'userCancelled' in error && (error as { userCancelled: boolean }).userCancelled) {
       console.log('User cancelled purchase');
       return null;
     }


### PR DESCRIPTION
This PR addresses several issues related to frontend hooks, services, and the Tailwind configuration:
- Replaces `any` with `Record<string, unknown>` or `unknown` where appropriate to improve type safety.
- Fixes potential infinite render loops by ensuring functions are wrapped in `useCallback` when used as `useEffect` dependencies.
- Safely handles error objects in catch blocks by using type guards.
- Correctly types sort callbacks in services.
- Ensures ESLint suppressions are correctly placed for third-party requires in configuration files.

---
*PR created automatically by Jules for task [13775221647056115873](https://jules.google.com/task/13775221647056115873) started by @3rdeyeadvisors*