### PR TITLE
Add back-to-home link to Auth page

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -265,7 +265,14 @@ export default function Auth() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 relative">
+      <div className="absolute top-4 left-4 z-10">
+        <Link to="/" className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors">
+          <ArrowLeft className="h-4 w-4" />
+          Back to home
+        </Link>
+      </div>
+
       {/* Background gradient effect */}
       <div className="fixed inset-0 overflow-hidden pointer-events-none">
         <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-primary/10 rounded-full blur-3xl" />


### PR DESCRIPTION
This PR adds a "Back to home" link at the top-left of the authentication page. 

Changes:
- Modified `src/pages/Auth.tsx` to add a `Link` component with the text "Back to home" and an `ArrowLeft` icon.
- Added the `relative` class to the main wrapper `div` of the `Auth` component to ensure correct absolute positioning of the link.
- Verified the layout and functionality via Playwright screenshot and navigation tests.

The `ArrowLeft` icon was already present in the `lucide-react` imports.

---
*PR created automatically by Jules for task [10816881201728478695](https://jules.google.com/task/10816881201728478695) started by @3rdeyeadvisors*