### PR TITLE
Fix unreliable auth redirection logic

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -36,9 +36,13 @@ export default function Auth() {
 
   // Redirect if already logged in
   useEffect(() => {
+    if (loading) return;
+    if (!user) return;
+
+    setIsRedirecting(true);
+
     const checkOnboarding = async () => {
-      if (user && !loading) {
-        setIsRedirecting(true);
+      try {
         const { data: profile } = await supabase
           .from('profiles')
           .select('onboarding_completed')
@@ -50,6 +54,9 @@ export default function Auth() {
         } else {
           navigate('/onboarding', { replace: true });
         }
+      } catch (error) {
+        // Profile doesn't exist yet (brand new user) — go to onboarding
+        navigate('/onboarding', { replace: true });
       }
     };
     


### PR DESCRIPTION
This change fixes an issue where users were occasionally stuck on the authentication page after a successful login or signup. The redirection logic is now more robust, with proper loading state management and fallback mechanisms for new users or network failures. I have verified that the auth page still renders correctly and that the new logic passes type checks within the context of the Auth page.

---
*PR created automatically by Jules for task [14331426125482293179](https://jules.google.com/task/14331426125482293179) started by @3rdeyeadvisors*